### PR TITLE
fs2-1.0.0-M4, cats-effect-1.0.0-RC3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,10 @@ name := "jawn-fs2"
 scalaVersion := "2.12.6"
 crossScalaVersions := Seq("2.11.12", scalaVersion.value)
 
-version := s"0.13.0-M2"
+version := s"0.13.0-M3"
 
 val JawnVersion   = "0.13.0"
-val Fs2Version    = "1.0.0-M3"
+val Fs2Version    = "1.0.0-M4"
 val Specs2Version = "4.3.3"
 
 libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.2.1

--- a/src/main/scala/jawnfs2/Absorbable.scala
+++ b/src/main/scala/jawnfs2/Absorbable.scala
@@ -1,6 +1,6 @@
 package jawnfs2
 
-import fs2.{Chunk, Segment}
+import fs2.Chunk
 import java.nio.ByteBuffer
 import jawn.{AsyncParser, ParseException, RawFacade}
 
@@ -25,11 +25,6 @@ object Absorbable {
   implicit val ByteArrayAbsorbable: Absorbable[Array[Byte]] = new Absorbable[Array[Byte]] {
     override def absorb[J](parser: AsyncParser[J], bytes: Array[Byte])(
         implicit rawFacade: RawFacade[J]): Either[ParseException, Seq[J]] = parser.absorb(bytes)
-  }
-
-  implicit def ByteSegmentAbsorbable[S <: Segment[Byte, _]]: Absorbable[S] = new Absorbable[S] {
-    override def absorb[J](parser: AsyncParser[J], segment: S)(
-      implicit rawFacade: RawFacade[J]): Either[ParseException, Seq[J]] = parser.absorb(segment.force.toArray)
   }
 
   implicit def ByteChunkAbsorbable[C <: Chunk[Byte]]: Absorbable[C] = new Absorbable[C] {

--- a/src/main/scala/jawnfs2/package.scala
+++ b/src/main/scala/jawnfs2/package.scala
@@ -1,3 +1,4 @@
+import cats.ApplicativeError
 import cats.effect.Sync
 import cats.implicits._
 import fs2.{Chunk, Pipe, Pull, Stream}
@@ -17,10 +18,10 @@ package object jawnfs2 {
     * @tparam J the JSON AST to return
     * @param mode the async mode of the Jawn parser
     */
-  def parseJson[F[_], A, J](mode: AsyncParser.Mode)(implicit A: Absorbable[A], facade: RawFacade[J]): Pipe[F, A, J] = {
+  def parseJson[F[_], A, J](mode: AsyncParser.Mode)(implicit F: ApplicativeError[F, Throwable], A: Absorbable[A], facade: RawFacade[J]): Pipe[F, A, J] = {
     def go(parser: AsyncParser[J])(s: Stream[F, A]): Pull[F, J, Unit] = {
       def handle(attempt: Either[ParseException, collection.Seq[J]]) =
-        attempt.fold(Pull.raiseError, js => Pull.output(Chunk.seq(js)))
+        attempt.fold(Pull.raiseError[F], js => Pull.output(Chunk.seq(js)))
 
       s.pull.uncons1.flatMap {
         case Some((a, stream)) =>
@@ -39,7 +40,7 @@ package object jawnfs2 {
     * @param facade the Jawn facade to materialize `J`
     * @tparam J the JSON AST to return
     */
-  def parseJsonStream[F[_], A, J](implicit A: Absorbable[A], facade: RawFacade[J]): Pipe[F, A, J] =
+  def parseJsonStream[F[_], A, J](implicit F: ApplicativeError[F, Throwable], A: Absorbable[A], facade: RawFacade[J]): Pipe[F, A, J] =
     parseJson(AsyncParser.ValueStream)
 
   /**
@@ -48,7 +49,7 @@ package object jawnfs2 {
     * @param facade the Jawn facade to materialize `J`
     * @tparam J the JSON AST to return
     */
-  def unwrapJsonArray[F[_], A, J](implicit A: Absorbable[A], facade: RawFacade[J]): Pipe[F, A, J] =
+  def unwrapJsonArray[F[_], A, J](implicit F: ApplicativeError[F, Throwable], A: Absorbable[A], facade: RawFacade[J]): Pipe[F, A, J] =
     parseJson(AsyncParser.UnwrapArray)
 
   /**
@@ -63,7 +64,7 @@ package object jawnfs2 {
       * @tparam J the JSON AST to return
       * @param mode the async mode of the Jawn parser
       */
-    def parseJson[J](mode: AsyncParser.Mode)(implicit absorbable: Absorbable[O], facade: RawFacade[J]): Stream[F, J] =
+    def parseJson[J](mode: AsyncParser.Mode)(implicit F: ApplicativeError[F, Throwable], A: Absorbable[O], facade: RawFacade[J]): Stream[F, J] =
       stream.through(jawnfs2.parseJson(mode))
 
     /**
@@ -73,7 +74,7 @@ package object jawnfs2 {
       * @tparam J the JSON AST to return
       * @return some parsed JSON value, or None if the source is empty
       */
-    def runJsonOption[J](implicit F: Sync[F], absorbable: Absorbable[O], facade: RawFacade[J]): F[Option[J]] =
+    def runJsonOption[J](implicit F: Sync[F], A: Absorbable[O], facade: RawFacade[J]): F[Option[J]] =
       stream.parseJson(AsyncParser.SingleValue).compile.last
 
     /**
@@ -84,7 +85,7 @@ package object jawnfs2 {
       * @return the parsed JSON value, or the facade's concept of jnull if the source is empty
       */
     @deprecated("Use runJsonOption.map(_.getOrElse(facade.jnull()))", "0.13.0")
-    def runJson[J](implicit F: Sync[F], absorbable: Absorbable[O], facade: Facade[J]): F[J] =
+    def runJson[J](implicit F: Sync[F], A: Absorbable[O], facade: Facade[J]): F[J] =
       runJsonOption.map(_.getOrElse(facade.jnull()))
 
     /**
@@ -93,7 +94,7 @@ package object jawnfs2 {
       * @param facade the Jawn facade to materialize `J`
       * @tparam J the JSON AST to return
       */
-    def parseJsonStream[J](implicit absorbable: Absorbable[O], facade: RawFacade[J]): Stream[F, J] =
+    def parseJsonStream[J](implicit F: ApplicativeError[F, Throwable], A: Absorbable[O], facade: RawFacade[J]): Stream[F, J] =
       stream.through(jawnfs2.parseJsonStream)
 
     /**
@@ -102,7 +103,7 @@ package object jawnfs2 {
       * @param facade the Jawn facade to materialize `J`
       * @tparam J the JSON AST to return
       */
-    def unwrapJsonArray[J](implicit absorbable: Absorbable[O], facade: RawFacade[J]): Stream[F, J] =
+    def unwrapJsonArray[J](implicit F: ApplicativeError[F, Throwable], A: Absorbable[O], facade: RawFacade[J]): Stream[F, J] =
       stream.through(jawnfs2.unwrapJsonArray)
   }
 }

--- a/src/test/scala/jawnfs2/JawnFs2Spec.scala
+++ b/src/test/scala/jawnfs2/JawnFs2Spec.scala
@@ -1,20 +1,21 @@
 package jawnfs2
 
+import cats.effect.{ContextShift, IO}
+import fs2.io.file.readAll
+import fs2.{Chunk, Stream}
 import java.nio.ByteBuffer
 import java.nio.file.Paths
-
-import cats.effect._
-import fs2.{Chunk, Stream}
-import fs2.io.file.readAll
 import jawn.AsyncParser
 import jawn.ast._
 import org.specs2.mutable.Specification
-
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class JawnFs2Spec extends Specification {
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(global)
+
   def loadJson(name: String, chunkSize: Int = 1024): Stream[IO, Chunk[Byte]] =
-    readAll[IO](Paths.get(s"testdata/$name.json"), chunkSize).chunks
+    readAll[IO](Paths.get(s"testdata/$name.json"), global, chunkSize).chunks
 
   implicit val facade = JParser.facade
 

--- a/src/test/scala/jawnfs2/examples/Example.scala
+++ b/src/test/scala/jawnfs2/examples/Example.scala
@@ -1,23 +1,33 @@
 package jawnfs2.examples
 
 import cats.effect._
+import cats.implicits._
 import fs2.{Stream, io, text}
 import java.nio.file.Paths
+import java.util.concurrent.Executors
 import jawnfs2._
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-object Example extends App {
+object Example extends IOApp {
   // Pick your favorite supported AST (e.g., json4s, argonaut, etc.)
   implicit val facade = jawn.ast.JawnFacade
 
-  // From JSON on disk
-  val jsonStream = io.file.readAll[IO](Paths.get("testdata/random.json"), 64)
-  // Introduce lag between chunks
-  val lag = Stream.awakeEvery[IO](500.millis)
-  val laggedStream = jsonStream.chunks.zipWith(lag)((chunk, _) => chunk)
-  // Print each element of the JSON array as we read it
-  val json = laggedStream.unwrapJsonArray.map(_.toString).intersperse("\n").through(text.utf8Encode)
-  // run converts the stream into an IO, unsafeRunSync executes the IO for its effects
-  json.to(io.stdout).compile.drain.unsafeRunSync
+  val blockingResource: Resource[IO, ExecutionContext] =
+    Resource.make(IO(Executors.newCachedThreadPool()))(es => IO(es.shutdown()))
+      .map(ExecutionContext.fromExecutorService)
+
+  def run(args: List[String]) =
+    // Uses blocking IO, so provide an appropriate thread pool
+    blockingResource.use { blockingEC =>
+      // From JSON on disk
+      val jsonStream = io.file.readAll[IO](Paths.get("testdata/random.json"), blockingEC, 64)
+      // Simulate lag between chunks
+      val lag = Stream.awakeEvery[IO](100.millis)
+      val laggedStream = jsonStream.chunks.zipWith(lag)((chunk, _) => chunk)
+      // Print each element of the JSON array as we read it
+      val json = laggedStream.unwrapJsonArray.map(_.toString).intersperse("\n").through(text.utf8Encode)
+      // run converts the stream into an IO, unsafeRunSync executes the IO for its effects
+      json.to[IO](io.stdout(blockingEC)).compile.drain.as(ExitCode.Success)
+    }
 }


### PR DESCRIPTION
Breaking changes:

- Many things need an `ApplicativeError[F, Throwable]` now.
- Need a blocking EC in the example